### PR TITLE
Set textContentType on login input fields for iOS password management

### DIFF
--- a/app/screens/Login.js
+++ b/app/screens/Login.js
@@ -93,6 +93,7 @@ class Login extends React.Component {
             onChangeText={username => this.setState({ username })}
             placeholder="Username"
             ref="username"
+            textContentType="username"
             returnKeyType="next"
             style={styles.input}
             value={this.state.username}
@@ -103,6 +104,7 @@ class Login extends React.Component {
             onChangeText={password => this.setState({ password })}
             placeholder="Password"
             ref="password"
+            textContentType="password"
             secureTextEntry={true}
             style={styles.input}
             value={this.state.password}


### PR DESCRIPTION
This enables iOS to provide it's built-in password management features in the login form.

Small recording of it in action - excuse the dodgy censoring I did to hide all my other logins https://gfycat.com/HilariousFarawayFairyfly

Going further, you could set up [Associated Domains][1] to make iOS suggest the the100.io password on the keyboard. This should also enable/improve integration with third party password managers (like 1Password) that's coming in iOS 12. https://twitter.com/1password/status/1003824297725460481?lang=en

[1]: https://developer.apple.com/documentation/security/password_autofill/setting_up_an_app_s_associated_domains